### PR TITLE
fix: stop using deprecated DEFAULT_FILE_STORAGE (unblocks CVE bump)

### DIFF
--- a/src/custom_storage/settings.py
+++ b/src/custom_storage/settings.py
@@ -1,9 +1,11 @@
 import datetime
-import sys
-import os
 import logging
-from django.core.exceptions import ImproperlyConfigured
+import os
+import sys
+
+import django
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 logger = logging.getLogger(__name__)
 
@@ -98,11 +100,18 @@ else:
 #     },
 # }
 
-settings.DEFAULT_FILE_STORAGE = setting(
-    "DEFAULT_FILE_STORAGE", settings.STORAGES["default"]["BACKEND"]
-)
+# DEFAULT_FILE_STORAGE was deprecated in Django 4.2 and removed in 5.1; reading
+# or assigning it raises under -W error::DeprecationWarning. Derive the default
+# backend from the modern STORAGES setting instead (honoring a legacy override
+# only on Django < 4.2, where the alias is still the source of truth).
+if django.VERSION < (4, 2):
+    _default_backend = setting(
+        "DEFAULT_FILE_STORAGE", settings.STORAGES["default"]["BACKEND"]
+    )
+else:
+    _default_backend = settings.STORAGES["default"]["BACKEND"]
 settings.THUMBNAIL_DEFAULT_STORAGE = setting(
-    "THUMBNAIL_DEFAULT_STORAGE", settings.DEFAULT_FILE_STORAGE
+    "THUMBNAIL_DEFAULT_STORAGE", _default_backend
 )
 
 if settings.FORCE_LOCAL_STORAGE:

--- a/src/custom_storage/storage.py
+++ b/src/custom_storage/storage.py
@@ -1,20 +1,20 @@
-from storages.backends.s3 import S3Storage
 from django.conf import settings
 from django.utils.module_loading import import_string
+from storages.backends.s3 import S3Storage
+
 from .settings import (
-    AWS_S3_STATIC_LOCATION,
-    AWS_S3_STATIC_URL,
     AWS_S3_MEDIA_LOCATION,
     AWS_S3_MEDIA_URL,
+    AWS_S3_STATIC_LOCATION,
+    AWS_S3_STATIC_URL,
 )
 
-# For Django 5.2+, get_storage_class was removed, use import_string instead
-try:
-    from django.core.files.storage import get_storage_class
-except ImportError:
-    # Django 5.2+ compatibility
-    def get_storage_class(import_path):
-        return import_string(import_path)
+# Django deprecated django.core.files.storage.get_storage_class in 4.2 and
+# removed it in 5.1. Always resolve via import_string so we never trigger
+# RemovedInDjango51Warning (which is fatal under -W error::DeprecationWarning)
+# nor break on Django 5.1+. Kept as a module-level name for backward compat.
+def get_storage_class(import_path):
+    return import_string(import_path)
 
 
 class StaticRootCachedS3Storage(S3Storage):
@@ -31,7 +31,7 @@ class StaticRootCachedS3Storage(S3Storage):
     def __init__(
         self, location=None, base_url=None, local_storage=None, *args, **kwargs
     ):
-        super(StaticRootCachedS3Storage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if location is None:
             self.location = AWS_S3_STATIC_LOCATION
         if base_url is None:
@@ -45,9 +45,7 @@ class StaticRootCachedS3Storage(S3Storage):
 
     def save(self, name, content, max_length=None):
         self.local_storage._save(name, content)
-        super(StaticRootCachedS3Storage, self).save(
-            name, self.local_storage._open(name)
-        )
+        super().save(name, self.local_storage._open(name))
         return name
 
 
@@ -65,7 +63,7 @@ class MediaRootCachedS3Storage(S3Storage):
     def __init__(
         self, location=None, base_url=None, local_storage=None, *args, **kwargs
     ):
-        super(MediaRootCachedS3Storage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if location is None:
             self.location = AWS_S3_MEDIA_LOCATION
         if base_url is None:
@@ -79,20 +77,18 @@ class MediaRootCachedS3Storage(S3Storage):
 
     def save(self, name, content, max_length=None):
         self.local_storage._save(name, content)
-        super(MediaRootCachedS3Storage, self).save(
-            name, self.local_storage._open(name)
-        )
+        super().save(name, self.local_storage._open(name))
         return name
 
     def delete(self, name):
         self.local_storage.delete(name)
-        super(MediaRootCachedS3Storage, self).delete(name)
+        super().delete(name)
 
         # Delete optimized image if exist
         for extension in ("webp", "avif"):
             print(f"{name}.{extension}")
             self.local_storage.delete(f"{name}.{extension}")
-            super(MediaRootCachedS3Storage, self).delete(f"{name}.{extension}")
+            super().delete(f"{name}.{extension}")
 
 
 class PublicMediaS3Boto3Storage(S3Storage):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,10 +2,10 @@
 
 import os
 
-from django.test import TestCase, override_settings
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase, override_settings
 
 import custom_storage
 from custom_storage.apps import CustomStorageConfig
@@ -37,10 +37,10 @@ class ModuleInstallationTestCase(TestCase):
     def test_storage_classes_can_be_imported(self):
         """Test that storage classes can be imported"""
         from custom_storage.storage import (
-            StaticRootCachedS3Storage,
             MediaRootCachedS3Storage,
-            PublicMediaS3Boto3Storage,
             PrivateMediaS3Boto3Storage,
+            PublicMediaS3Boto3Storage,
+            StaticRootCachedS3Storage,
         )
 
         self.assertTrue(StaticRootCachedS3Storage)
@@ -143,6 +143,7 @@ class SettingsConfigurationTestCase(TestCase):
         with self.assertRaises(ImproperlyConfigured):
             # Reload settings module to trigger validation
             import importlib
+
             import custom_storage.settings as settings_module
 
             importlib.reload(settings_module)
@@ -208,9 +209,13 @@ class STORAGESConfigurationTestCase(TestCase):
         )
 
     def test_default_file_storage_is_set(self):
-        """Test that DEFAULT_FILE_STORAGE is set"""
-        self.assertTrue(hasattr(settings, "DEFAULT_FILE_STORAGE"))
-        self.assertIsNotNone(settings.DEFAULT_FILE_STORAGE)
+        """Test that the default storage backend is configured via STORAGES.
+
+        DEFAULT_FILE_STORAGE was deprecated in Django 4.2 and removed in 5.1;
+        STORAGES['default'] is the source of truth on supported Django.
+        """
+        self.assertIn("default", settings.STORAGES)
+        self.assertIsNotNone(settings.STORAGES["default"]["BACKEND"])
 
     def test_thumbnail_default_storage_is_set(self):
         """Test that THUMBNAIL_DEFAULT_STORAGE is set"""
@@ -333,7 +338,6 @@ class IntegrationConfigurationTestCase(TestCase):
             "COMPRESS_ENABLED",
             "COMPRESS_OFFLINE",
             "STORAGES",
-            "DEFAULT_FILE_STORAGE",
         ]
 
         for setting_name in required_settings:

--- a/tests/test_django_compatibility.py
+++ b/tests/test_django_compatibility.py
@@ -1,8 +1,8 @@
 """Tests for Django version compatibility (4.2 vs 5.2)"""
 
-from django.test import TestCase, override_settings
-from django.conf import settings
 from django import VERSION as DJANGO_VERSION
+from django.conf import settings
+from django.test import TestCase, override_settings
 
 
 class Django42STORAGESCompatibilityTestCase(TestCase):
@@ -55,33 +55,33 @@ class Django42STORAGESCompatibilityTestCase(TestCase):
 
 
 class DjangoDefaultFileStorageDeprecationTestCase(TestCase):
-    """Test DEFAULT_FILE_STORAGE deprecation vs STORAGES"""
+    """Test the STORAGES-based default storage configuration.
 
-    def test_default_file_storage_exists(self):
-        """Test that DEFAULT_FILE_STORAGE still exists (backward compatibility)"""
-        # DEFAULT_FILE_STORAGE is deprecated but still supported for backward compatibility
-        self.assertTrue(hasattr(settings, "DEFAULT_FILE_STORAGE"))
-        self.assertIsNotNone(settings.DEFAULT_FILE_STORAGE)
+    DEFAULT_FILE_STORAGE / STATICFILES_STORAGE were deprecated in Django 4.2 and
+    removed in 5.1; accessing them raises under -W error::DeprecationWarning, so
+    on supported Django the default backend is read from STORAGES instead.
+    """
 
-    def test_default_file_storage_matches_storages(self):
-        """Test that DEFAULT_FILE_STORAGE matches STORAGES['default']['BACKEND']"""
-        # In Django 4.2+, DEFAULT_FILE_STORAGE should match STORAGES['default']['BACKEND']
-        if DJANGO_VERSION >= (4, 2):
+    def test_default_backend_configured_via_storages(self):
+        """The default backend is configured via STORAGES['default']."""
+        self.assertIn("default", settings.STORAGES)
+        self.assertIsNotNone(settings.STORAGES["default"]["BACKEND"])
+
+    def test_legacy_default_file_storage_only_pre_42(self):
+        """The deprecated alias is only consulted on Django < 4.2."""
+        if DJANGO_VERSION < (4, 2):
+            self.assertTrue(hasattr(settings, "DEFAULT_FILE_STORAGE"))
             self.assertEqual(
                 settings.DEFAULT_FILE_STORAGE,
                 settings.STORAGES["default"]["BACKEND"],
             )
 
-    def test_staticfiles_storage_exists_if_storages_staticfiles(self):
-        """Test STATICFILES_STORAGE exists when STORAGES['staticfiles'] is set"""
-        # STATICFILES_STORAGE is deprecated but still supported
+    def test_staticfiles_backend_via_storages(self):
+        """Staticfiles backend, when present, lives in STORAGES['staticfiles']."""
         if "staticfiles" in settings.STORAGES:
-            if hasattr(settings, "STATICFILES_STORAGE"):
-                # They should match
-                self.assertEqual(
-                    settings.STATICFILES_STORAGE,
-                    settings.STORAGES["staticfiles"]["BACKEND"],
-                )
+            self.assertIsNotNone(
+                settings.STORAGES["staticfiles"]["BACKEND"]
+            )
 
 
 class DjangoStorageObjectTestCase(TestCase):
@@ -141,9 +141,9 @@ class Django52GetStorageClassRemovalTestCase(TestCase):
     def test_get_storage_class_import(self):
         """Test that get_storage_class import works or falls back"""
         try:
-            from django.core.files.storage import (
+            from django.core.files.storage import (  # noqa: F401
                 get_storage_class,
-            )  # noqa: F401
+            )
 
             # If import works, it's Django < 5.1
             self.assertTrue(True, "get_storage_class available in older Django")
@@ -210,8 +210,8 @@ class DjangoVersionSpecificBehaviorTestCase(TestCase):
     def test_custom_storage_classes_work_all_versions(self):
         """Test that custom storage classes work in all Django versions"""
         from custom_storage.storage import (
-            StaticRootCachedS3Storage,
             MediaRootCachedS3Storage,
+            StaticRootCachedS3Storage,
         )
 
         # Should be able to instantiate (with mocked dependencies)
@@ -224,36 +224,34 @@ class DjangoMigrationPathTestCase(TestCase):
     """Test migration path from old to new storage API"""
 
     def test_both_default_file_storage_and_storages_exist(self):
-        """Test that both old and new settings exist (transition period)"""
-        # During migration, both might exist
-        has_default_file_storage = hasattr(settings, "DEFAULT_FILE_STORAGE")
-        has_storages = hasattr(settings, "STORAGES")
+        """STORAGES is the source of truth; the legacy alias is only consulted
+        on Django < 4.2 (accessing it on 4.2+ raises under -W error)."""
+        self.assertTrue(hasattr(settings, "STORAGES"))
+        self.assertIn("default", settings.STORAGES)
 
-        # At least one should exist
-        self.assertTrue(has_default_file_storage or has_storages)
-
-        # If both exist, they should be consistent
-        if has_default_file_storage and has_storages:
-            if DJANGO_VERSION >= (4, 2):
-                self.assertEqual(
-                    settings.DEFAULT_FILE_STORAGE,
-                    settings.STORAGES["default"]["BACKEND"],
-                )
+        if DJANGO_VERSION < (4, 2) and hasattr(
+            settings, "DEFAULT_FILE_STORAGE"
+        ):
+            self.assertEqual(
+                settings.DEFAULT_FILE_STORAGE,
+                settings.STORAGES["default"]["BACKEND"],
+            )
 
     def test_staticfiles_storage_consistency(self):
-        """Test consistency between STATICFILES_STORAGE and STORAGES['staticfiles']"""
-        has_staticfiles_storage = hasattr(settings, "STATICFILES_STORAGE")
+        """STATICFILES_STORAGE (legacy) consistency is only checked on Django
+        < 4.2; on 4.2+ STORAGES['staticfiles'] is authoritative."""
         has_storages_staticfiles = (
             hasattr(settings, "STORAGES") and "staticfiles" in settings.STORAGES
         )
-
-        # If both exist, they should match
-        if has_staticfiles_storage and has_storages_staticfiles:
-            if DJANGO_VERSION >= (4, 2):
-                self.assertEqual(
-                    settings.STATICFILES_STORAGE,
-                    settings.STORAGES["staticfiles"]["BACKEND"],
-                )
+        if (
+            DJANGO_VERSION < (4, 2)
+            and has_storages_staticfiles
+            and hasattr(settings, "STATICFILES_STORAGE")
+        ):
+            self.assertEqual(
+                settings.STATICFILES_STORAGE,
+                settings.STORAGES["staticfiles"]["BACKEND"],
+            )
 
 
 class DjangoStorageBackendCompatibilityTestCase(TestCase):


### PR DESCRIPTION
## Summary

Fixes a pre-existing CI failure that blocks the Django security CVE lock bump (PR #513). `custom_storage/settings.py` used the **deprecated `DEFAULT_FILE_STORAGE`** setting (deprecated in Django 4.2, removed in 5.1). Accessing it raises `RemovedInDjango51Warning`, and the fleet `tox` runs pytest with `-W error::DeprecationWarning`, so `django.setup()` crashed on every Django 4.2 leg (py3.9-3.12).

## Changes

- `src/custom_storage/settings.py`: derive the default backend from `STORAGES["default"]["BACKEND"]`; only consult the legacy `DEFAULT_FILE_STORAGE` alias on Django < 4.2. No more read/assign of the deprecated setting on supported Django.
- `tests/test_configuration.py`: assert the default backend via `STORAGES`; drop `DEFAULT_FILE_STORAGE` from the required-settings list.
- `tests/test_django_compatibility.py`: validate `STORAGES`; guard all legacy-alias access behind `DJANGO_VERSION < (4, 2)`.

## Why it matters

Part of the AR-033 security non-regression work: this unblocks the Django >= 4.2.30 CVE remediation for `django-custom-storage` and removes a deprecated-API liability ahead of Django 5.1.

## Test plan

- [ ] `ci / test` green on all Django 4.2 legs (previously crashing at `django.setup()`)
- [ ] Re-run/rebase the dependency-upgrade PR (#513) on top; expect green + CVE bump merged
